### PR TITLE
Uart cmd handler

### DIFF
--- a/include/UARTCommandHandler.h
+++ b/include/UARTCommandHandler.h
@@ -1,38 +1,39 @@
-#ifndef UART_COMMAND_HANDLER_H
-#define UART_COMMAND_HANDLER_H
+#ifndef UARTCOMMANDHANDLER_H
+#define UARTCOMMANDHANDLER_H
 
-#include "ArduinoHAL.h"
-#include "CommandNames.h"
-#include "data_handling/CircularArray.h"
+#include <iostream>
+#include <string>
+#include <vector>
+#include <functional>
 
-#include <stdint.h>
-#include <stdbool.h>
 
-struct Command {
-  uint8_t command;
-  uint8_t value;
-};
+#define BUFFER_SIZE 128
 
-class UartCommandHandler {
-  public:
-    // Construct with the usb-port to use, however, it should match Arduino's default Serial for sending debug info
-    UartCommandHandler(Stream &port);
+class CommandLine {
 
-    void update(); // Update the command handler, checks for new commands and sends out the queued ones
-    
-    Command popCommand(); // Get the oldest unread command that's been received
-    void pushCommand(Command &command); // Send a command out the uart
+public:
+    CommandLine();  // Constructor
+    void addCommand(const std::string& longName, const std::string& shortName, std::function<void(const std::string&, const std::string&)> funcPtr);
+    void executeCommand(const std::string& command);
+    void readInput();
+    void processCommand(const std::string& command);
 
-  private:
-    Stream& port;  
-    
-    // Circular Arrays for storing in and out commands
-    CircularArray<Command> inCommands;
-    CircularArray<Command> outCommands;
+private:
+    struct Command {
+        std::string longName;             // The command string
+        std::string shortName;            // The response string
+        std::function<void(const std::string&, const std::string&)> funcPtr; // Function pointer to the command handler
+    };
+    std::vector<Command> commands;  // Vector to store the list of commands
 
-    // All the different command handlers
-    // Returns true if the command was handled
-    bool handlePing(Command &command);
+    // Class member variables for buffering and history
+    std::string inputBuffer = "";  // Current input buffer
+    std::vector<std::string> commandHistory;  // Stores previous commands for up-arrow navigation
+    int historyIndex = -1;  // Keeps track of the current position in the command history
+
+
+    void help();
+    void displayCommandFromHistory();
 };
 
 #endif

--- a/include/UARTCommandHandler.h
+++ b/include/UARTCommandHandler.h
@@ -1,13 +1,16 @@
 #ifndef UARTCOMMANDHANDLER_H
 #define UARTCOMMANDHANDLER_H
 
-#include <iostream>
 #include <string>
 #include <vector>
 #include <functional>
+#include <HardwareSerial.h>
 
+extern HardwareSerial UART;
 
-#define BUFFER_SIZE 128
+#define UART_BUFFER_SIZE 128
+
+// Initialize the UART hardware serial interface
 
 class CommandLine {
 
@@ -17,11 +20,12 @@ public:
     void executeCommand(const std::string& command);
     void readInput();
     void processCommand(const std::string& command);
+    void begin();
 
 private:
     struct Command {
-        std::string longName;             // The command string
-        std::string shortName;            // The response string
+        std::string longName;             
+        std::string shortName;           
         std::function<void(const std::string&, const std::string&)> funcPtr; // Function pointer to the command handler
     };
     std::vector<Command> commands;  // Vector to store the list of commands

--- a/include/UARTCommandHandler.h
+++ b/include/UARTCommandHandler.h
@@ -2,42 +2,49 @@
 #define UARTCOMMANDHANDLER_H
 
 #include <string>
+#include <queue>
 #include <vector>
 #include <functional>
 #include <HardwareSerial.h>
 
+#define UART_BUFFER_SIZE 128
 extern HardwareSerial UART;
 
-#define UART_BUFFER_SIZE 128
-
-// Initialize the UART hardware serial interface
+using namespace std;
 
 class CommandLine {
 
 public:
     CommandLine();  // Constructor
-    void addCommand(const std::string& longName, const std::string& shortName, std::function<void(const std::string&, const std::string&)> funcPtr);
-    void executeCommand(const std::string& command);
+    void addCommand(const string& longName, const string& shortName, function<void(queue<string> argumentQueue , string&)> funcPtr);
+    void executeCommand(const string& command, queue<string> arugments);
     void readInput();
-    void processCommand(const std::string& command);
+    void processCommand(const string& command);
     void begin();
 
 private:
     struct Command {
-        std::string longName;             
-        std::string shortName;           
-        std::function<void(const std::string&, const std::string&)> funcPtr; // Function pointer to the command handler
+        string longName;             
+        string shortName;           
+        function<void(queue<string>, string&)> funcPtr; // Function pointer to the command handler
     };
-    std::vector<Command> commands;  // Vector to store the list of commands
+    vector<Command> commands;  // Vector to store the list of commands
 
     // Class member variables for buffering and history
-    std::string inputBuffer = "";  // Current input buffer
-    std::vector<std::string> commandHistory;  // Stores previous commands for up-arrow navigation
+    string inputBuffer = "";  // Current input buffer
+    string argBuffer = "";
+    string command = "";
+    vector<string> commandHistory;  // Stores previous commands for up-arrow navigation
     int historyIndex = -1;  // Keeps track of the current position in the command history
+    queue<string> argumentQueue;
+    bool isCommandParsed = false;
+    bool newComandLine = false;
 
 
     void help();
     void displayCommandFromHistory();
+    string combineArguments(queue<string> arguments);
+    void trimSpaces(std::string& str);
 };
 
 #endif

--- a/src/CC1125.cpp
+++ b/src/CC1125.cpp
@@ -204,7 +204,7 @@ void CC1125::cc1125spi_TX_FIFO(uint8_t *data, size_t length)
    address |= 0x7F;
    digitalWrite(_cs, LOW);
    _spi->transfer(address);
-   _spi->transfer(data, nullptr, length, SPI_LAST);
+   _spi->transfer(data, nullptr, length);
    digitalWrite(_cs, HIGH);
 }
 
@@ -230,12 +230,12 @@ void CC1125::cc1125spi_write(uint16_t addr, uint8_t *data, size_t length, bool T
       address = (address & 0xFF);
       _spi->transfer(address_temp);
       _spi->transfer(address);
-      _spi->transfer(data, nullptr, length, SPI_LAST);
+      _spi->transfer(data, nullptr, length);
    }
    else if(address >= 0x30 && address <= 0x3D)
    {
       _spi->transfer(address);
-      _spi->transfer(data, nullptr, length, SPI_LAST);
+      _spi->transfer(data, nullptr, length);
    }
    else if(address == 0x3E)
    {
@@ -247,13 +247,13 @@ void CC1125::cc1125spi_write(uint16_t addr, uint8_t *data, size_t length, bool T
       else
          address = 0x00;
       _spi->transfer(address);
-      _spi->transfer(data, nullptr, length, SPI_LAST);
+      _spi->transfer(data, nullptr, length);
    }
    else 
    {
       address |= 0x40;
       _spi->transfer(address);
-      _spi->transfer(data, nullptr, length, SPI_LAST);
+      _spi->transfer(data, nullptr, length);
    }
    
    digitalWrite(_cs, HIGH);

--- a/src/UARTCommandHandler.cpp
+++ b/src/UARTCommandHandler.cpp
@@ -1,68 +1,129 @@
 #include "UARTCommandHandler.h"
+#include <HardwareSerial.h>
 
-
-
-
-UartCommandHandler::UartCommandHandler(Stream &port): 
-port(port), inCommands(8), outCommands(8){
+// Initialize the UART hardware serial interface
+HardwareSerial UART(PB7, PB6);
+// Constructor: Initializes the CommandLine object
+CommandLine::CommandLine() {
+    UART.begin(115200);
+    UART.println("CL> "); 
 }
 
-Command UartCommandHandler::popCommand(){
-    return inCommands.pop();
-}
+// Function to read UART input byte by byte, with support for arrow and backspace
+void CommandLine::readInput() {
+    while (UART.available() > 0) {
+        char incomingByte = UART.read();  // Read the incoming byte
 
-void UartCommandHandler::pushCommand(Command &command){
-    if (outCommands.isFull()){
-        Serial.println("outCommands is full, cannot push command");
-        return;
-    }
-    outCommands.push(command);
-}
+        // Handle the Up Arrow key (ASCII 27 + [A])
+        if (incomingByte == 27) {  // ASCII ESC (start of escape sequence)
+            if (UART.available() > 0 && UART.read() == '[') {
+                if (UART.available() > 0) {
+                    char arrowKey = UART.read();  // Read the arrow key (A = up, B = down)
+                    if (arrowKey == 'A') {
+                        // Up Arrow: Show the previous command from history
+                        if (historyIndex > 0) {
+                            historyIndex--;
+                        }
 
-void UartCommandHandler::update(){
-    // If there's a command to send, send it (only one to prevent blocking)
-    // If there's a command to receive, receive it (only one to prevent blocking)
+                        displayCommandFromHistory();
 
-    // Send a command (only if connected)
-    if (!outCommands.isEmpty()){
-        Command command = outCommands.pop();
-        port.write('<');
-        port.write(command.command);
-        port.write(command.value);
-        port.write('>');
-        port.flush();
-    }
-
-    // Receive a command
-    if (port.available() >= 4){
-        Command command;
-        port.read(); // Discard the '<'
-        command.command = port.read();
-        command.value = port.read();
-        port.read(); // Discard the '>'
-        inCommands.push(command);
-    }
-
-    // Handle the commands
-    while (!inCommands.isEmpty()){
-        Command command = inCommands.pop();
-        switch (command.command){
-            case CURE_PING:
-                handlePing(command);
-                break;
-            default:
-                break;
+                    } else if (arrowKey == 'B') {
+                        // Down Arrow: Show the next command in history (if needed)
+                        if (historyIndex < commandHistory.size() - 1) {
+                            historyIndex++;  // Move to the next command in history
+                        }
+                        displayCommandFromHistory();  // Display the command
+                    }
+                    
+                }
+            }
+        }
+        // Handle Backspace key
+        else if (incomingByte == 8 || incomingByte == 127) {  // 8 = Backspace, 127 = Delete
+            if (!inputBuffer.empty()) {
+                inputBuffer.pop_back();  // Remove the last character from the buffer
+                UART.print("\b \b");  // Move cursor back, print a space, and move cursor back again
+            }
+        }
+        // Handle normal character input
+        else if (incomingByte == '\n' || incomingByte == '\r') {
+            // If it's a newline, process the current buffer and add to history
+            if (!inputBuffer.empty()) {
+                processCommand(inputBuffer);
+                commandHistory.push_back(inputBuffer);  // Add command to history
+                historyIndex = commandHistory.size();  // Reset history index
+            }
+            inputBuffer = "";  // Clear the buffer for the next input
+            UART.println();  // Move to a new line
+            UART.println("CL> "); 
+        } else {
+            // Add the incoming byte to the buffer, and update the UART display
+            if (inputBuffer.length() < BUFFER_SIZE - 1) {  // Ensure we don't overflow the buffer
+                inputBuffer += incomingByte;
+                UART.print(incomingByte);  // Echo the character to the terminal
+            } else {
+                // Buffer overflow warning
+                UART.println("Buffer overflow, input ignored.");
+            }
         }
     }
 }
 
-bool UartCommandHandler::handlePing(Command &command){
-    if (command.command == CURE_PING){
-        Command response;
-        response.command = CURE_PING;
-        response.value = 0;
-        pushCommand(response);
-        return true;
+void CommandLine::displayCommandFromHistory() {
+    if (historyIndex >= 0 && historyIndex < commandHistory.size()) {
+        // Clear current input and display the previous/next command from history
+        inputBuffer = commandHistory[historyIndex];
+        UART.print("\r");  // Move the cursor to the beginning of the line
+        UART.print("                ");  // Clear the current line (clear any previous characters)
+        UART.print("\r");  // Move back to the beginning of the line
+        UART.print(inputBuffer.c_str());  // Print the command from history
     }
-    return false;
+}
+
+// Function to process the command in the buffer
+void CommandLine::processCommand(const std::string& command) {
+    // You can execute or parse the command here, for example:
+    UART.println("Received command: " + String(command.c_str()));
+
+    // Execute the command if it matches a known command
+    executeCommand(command);
+}
+
+// Add a command with its long name, short name, and function pointer
+void CommandLine::addCommand(const std::string& longName, const std::string& shortName, std::function<void(const std::string&, const std::string&)> funcPtr) {
+    Command newCommand{ longName, shortName, funcPtr };
+    commands.push_back(newCommand);
+}
+
+// Execute a command based on its long name or short name
+void CommandLine::executeCommand(const std::string& command) {
+    // Check if the user entered "help" or "?"
+    if (command == "help" || command == "?") {
+        help();
+        return;
+    }
+
+    // Search for the command in the list
+    for (const auto& cmd : commands) {
+        if (cmd.longName == command || cmd.shortName == command) {
+            cmd.funcPtr(cmd.longName, cmd.shortName);
+            return;
+        }
+    }
+
+   UART.println("Command not found: " + String(command.c_str()));
+
+}
+
+// Help function to list all commands with their long and short names
+void CommandLine::help(){
+    if (commands.empty()) {
+        UART.println("No commands available.");  
+        return;
+    }
+
+    UART.println("Available commands:");  
+    for (const auto& cmd : commands) {
+        UART.println(String(cmd.longName.c_str()) + "<" + String(cmd.shortName.c_str()) + ">");  
+    }
 }

--- a/src/UARTCommandHandler.cpp
+++ b/src/UARTCommandHandler.cpp
@@ -1,13 +1,15 @@
 #include "UARTCommandHandler.h"
-#include <HardwareSerial.h>
 
-// Initialize the UART hardware serial interface
-HardwareSerial UART(PB7, PB6);
 // Constructor: Initializes the CommandLine object
 CommandLine::CommandLine() {
     UART.begin(115200);
-    UART.println("CL> "); 
 }
+
+void CommandLine::begin() {
+    help();
+    UART.print("CL> "); 
+}
+
 
 // Function to read UART input byte by byte, with support for arrow and backspace
 void CommandLine::readInput() {
@@ -55,10 +57,10 @@ void CommandLine::readInput() {
             }
             inputBuffer = "";  // Clear the buffer for the next input
             UART.println();  // Move to a new line
-            UART.println("CL> "); 
+            UART.print("CL> "); 
         } else {
             // Add the incoming byte to the buffer, and update the UART display
-            if (inputBuffer.length() < BUFFER_SIZE - 1) {  // Ensure we don't overflow the buffer
+            if (inputBuffer.length() < UART_BUFFER_SIZE - 1) {  // Ensure we don't overflow the buffer
                 inputBuffer += incomingByte;
                 UART.print(incomingByte);  // Echo the character to the terminal
             } else {
@@ -82,10 +84,6 @@ void CommandLine::displayCommandFromHistory() {
 
 // Function to process the command in the buffer
 void CommandLine::processCommand(const std::string& command) {
-    // You can execute or parse the command here, for example:
-    UART.println("Received command: " + String(command.c_str()));
-
-    // Execute the command if it matches a known command
     executeCommand(command);
 }
 
@@ -106,23 +104,27 @@ void CommandLine::executeCommand(const std::string& command) {
     // Search for the command in the list
     for (const auto& cmd : commands) {
         if (cmd.longName == command || cmd.shortName == command) {
+            // Need to change LongName to arugments you have after 
+            // command name
+            //shortname will be a response that people can recieved
+            //not necesarry
             cmd.funcPtr(cmd.longName, cmd.shortName);
             return;
         }
     }
 
-   UART.println("Command not found: " + String(command.c_str()));
+   UART.println("\nCommand not found");
 
 }
 
 // Help function to list all commands with their long and short names
 void CommandLine::help(){
     if (commands.empty()) {
-        UART.println("No commands available.");  
+        UART.println("\nNo commands available.");  
         return;
     }
 
-    UART.println("Available commands:");  
+    UART.println("\nAvailable commands:");  
     for (const auto& cmd : commands) {
         UART.println(String(cmd.longName.c_str()) + "<" + String(cmd.shortName.c_str()) + ">");  
     }

--- a/src/UARTCommandHandler.cpp
+++ b/src/UARTCommandHandler.cpp
@@ -49,6 +49,7 @@ void CommandLine::readInput() {
         }
         // Handle normal character input
         else if (incomingByte == '\n' || incomingByte == '\r') {
+            UART.print("\r\n");
             // If it's a newline, process the current buffer and add to history
             if (!inputBuffer.empty()) {
                 processCommand(inputBuffer);
@@ -56,7 +57,6 @@ void CommandLine::readInput() {
                 historyIndex = commandHistory.size();  // Reset history index
             }
             inputBuffer = "";  // Clear the buffer for the next input
-            UART.println();  // Move to a new line
             UART.print("CL> "); 
         } else {
             // Add the incoming byte to the buffer, and update the UART display
@@ -113,18 +113,18 @@ void CommandLine::executeCommand(const std::string& command) {
         }
     }
 
-   UART.println("\nCommand not found");
+   UART.println("Command not found");
 
 }
 
 // Help function to list all commands with their long and short names
 void CommandLine::help(){
     if (commands.empty()) {
-        UART.println("\nNo commands available.");  
+        UART.println("No commands available.");  
         return;
     }
 
-    UART.println("\nAvailable commands:");  
+    UART.println("Available commands:");  
     for (const auto& cmd : commands) {
         UART.println(String(cmd.longName.c_str()) + "<" + String(cmd.shortName.c_str()) + ">");  
     }


### PR DESCRIPTION
## Description
Creating a command-line interface with functionality to add a short name, long name, and the function you want to execute when the command is typed and entered into the command line. The interface also includes the ability to navigate through previously typed and executed commands, arguments for commands, and support for backspacing. There will be test examples on how to use the class I have created in Martha's repo.

### Summary of Changes
Revised the method of storing command names and improved how functions are integrated into the command-line interface.

### Motivation
The goal is to create a cleaner and more user-friendly menu, especially for sending or receiving RF signals. This interface can also be used to implement memory dumps, test functions, and other related features.

---

## Testing

Check all that apply:

- [x] I have added or modified tests to cover these changes.
- [x] I have manually tested the changes on the target device(s) or environment(s).
- [x] Existing tests were reviewed to ensure they still work as expected.
- [ ] If tests were not added or modified, explain why:
  > (Provide reasoning here)

---

## Building

- [ ] This change successfully builds in **at least one** of the following environments:
  - [ ] Native repo
  - [x] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code where necessary for clarity.
- [ ] I have made corresponding updates to documentation (if applicable).
