### PR TITLE
Allowing passing in any Stream for command line 

### DIFF
--- a/include/UARTCommandHandler.h
+++ b/include/UARTCommandHandler.h
@@ -8,6 +8,8 @@
 #include <HardwareSerial.h>
 
 #define UART_BUFFER_SIZE 128
+#define MAX_HISTORY      20
+#define MAX_ARGUMENTS    5
 
 using namespace std;
 
@@ -39,14 +41,17 @@ private:
     vector<Command> commands;  // Vector to store the list of commands
 
     // Class member variables for buffering and history
+    string fullLine = {""}; 
     string inputBuffer = "";  // Current input buffer
     string argBuffer = "";
     string command = "";
-    vector<string> commandHistory;  // Stores previous commands for up-arrow navigation
-    int historyIndex = -1;  // Keeps track of the current position in the command history
+    string fullLineHistory[MAX_HISTORY] = {""}; 
+    string commandHistory[MAX_HISTORY];  // Stores previous commands for up-arrow navigation
+    int historyIndex = 0;  // Keeps track of the current position in the command history
     queue<string> argumentQueue;
+    string argumentHistory[MAX_HISTORY][MAX_ARGUMENTS];
+    int argSize[MAX_HISTORY];
     bool isCommandParsed = false;
-    bool newComandLine = false;
 
 
     void help();

--- a/include/UARTCommandHandler.h
+++ b/include/UARTCommandHandler.h
@@ -8,21 +8,29 @@
 #include <HardwareSerial.h>
 
 #define UART_BUFFER_SIZE 128
-extern HardwareSerial UART;
 
 using namespace std;
 
 class CommandLine {
 
 public:
-    CommandLine();  // Constructor
+    CommandLine(Stream * UART);  // Constructor
     void addCommand(const string& longName, const string& shortName, function<void(queue<string> argumentQueue , string&)> funcPtr);
     void executeCommand(const string& command, queue<string> arugments);
     void readInput();
     void processCommand(const string& command);
     void begin();
 
+    // Pass-through functions for the UART object
+    void println(const string& message){
+        UART->println(message.c_str());
+    }
+    void print(const string& message){
+        UART->print(message.c_str());
+    }
+
 private:
+    Stream * UART;  // Pointer to the UART object
     struct Command {
         string longName;             
         string shortName;           

--- a/src/UARTCommandHandler.cpp
+++ b/src/UARTCommandHandler.cpp
@@ -34,7 +34,7 @@ void CommandLine::readInput() {
                     displayCommandFromHistory();
                 } else if (incomingByte == 'B') {
                     // Down Arrow
-                    if (historyIndex < commandHistory.size() - 1) {
+                    if (historyIndex < MAX_HISTORY) {
                         historyIndex++;
                     }
                     displayCommandFromHistory();
@@ -46,64 +46,81 @@ void CommandLine::readInput() {
         }
         else if (incomingByte == 8 || incomingByte == 127)  // 8 = Backspace, 127 = Delete
         { 
-            if (!inputBuffer.empty()) {
-                inputBuffer.pop_back();  // Remove the last character from the buffer
+            if (!fullLine.empty()) {
+                fullLine.pop_back();  // Remove the last character from the buffer
                 UART->print("\b \b");  // Move cursor back, print a space, and move cursor back again
+                
+                if(!inputBuffer.empty()){
+                    inputBuffer.pop_back(); 
+                }
+                //TODO FIX: If you back space on a history command it will not erase
+                //the command or argument buffer, so if you press enter it will
+                // return prevous commmand
             }
         }
         else if (incomingByte == ' ')
         {
             UART->print(incomingByte);
-            if (!inputBuffer.empty() || !argBuffer.empty()) {
+            fullLine += incomingByte;
+
+            if (!inputBuffer.empty()) {
                 if (!isCommandParsed) {
                     command = inputBuffer;
                     isCommandParsed = true;
                 } else {
-                    
-                    argumentQueue.push(argBuffer);  // Push subsequent words as arguments
+                    if(argSize[historyIndex] < MAX_ARGUMENTS){
+                        argumentQueue.push(inputBuffer);  // Push subsequent words as arguments
+                        argSize[historyIndex]++;
+                    }
                 }
-                argBuffer.clear();  // Clear buffer for the next input
             }
-            inputBuffer += incomingByte;
+            inputBuffer.clear();
         }
         else if (incomingByte == '\n' || incomingByte == '\r') 
         {
             UART->println();
+            int idx= 0;
             // If it's a newline, process the current buffer and add to history
             if (!inputBuffer.empty()) {
-                if(isCommandParsed)
-                    argumentQueue.push(argBuffer);
+                if(isCommandParsed || !command.empty())
+                {   
+                    argumentQueue.push(inputBuffer);
+                    argSize[historyIndex]++;
+                }
                 else
+                {
                     command = inputBuffer;
-                executeCommand(command, argumentQueue);
-                commandHistory.push_back(command);
-                historyIndex = commandHistory.size();
+                }
+            }
 
-                newComandLine = true;
+            if(!command.empty() || !argumentQueue.empty())
+            {
+                executeCommand(command, argumentQueue);
+                commandHistory[historyIndex] = command;
+                fullLineHistory[historyIndex] = fullLine;
+
+                while (!argumentQueue.empty()) {
+                    argumentHistory[historyIndex][idx] = argumentQueue.front();
+                    argumentQueue.pop();  // Clear the argument queue
+                    idx++;
+                }
+                historyIndex++;
             }
 
             inputBuffer.clear();  // Clear the buffer for the next input
             command.clear();
+            fullLine.clear();
             isCommandParsed = false;
-            while (!argumentQueue.empty()) {
-                argumentQueue.pop();  // Clear the argument queue
-            }
             UART->print("CL> "); 
 
             
         } else {
             // Add the incoming byte to the buffer, and update the UART display
             if (inputBuffer.length() < UART_BUFFER_SIZE - 1) {  // Ensure we don't overflow the buffer
-                if(isCommandParsed == false){
-                    inputBuffer += incomingByte;
-                    UART->print(incomingByte);  // Echo the character to the terminal
-                }
-                else
-                {
-                    argBuffer += incomingByte;
-                    inputBuffer += incomingByte;
-                    UART->print(incomingByte);
-                }
+                inputBuffer += incomingByte;
+                fullLine += incomingByte;
+                UART->print(incomingByte);  // Echo the character to the terminal
+
             } else {
                 UART->println("Buffer overflow, input ignored.");
             }
@@ -113,17 +130,50 @@ void CommandLine::readInput() {
 }
 
 void CommandLine::displayCommandFromHistory() {
-    if (historyIndex >= 0 && historyIndex < commandHistory.size()) {
+
+    if (historyIndex >= MAX_HISTORY) {
+        // Reset the history index to 0 (wrap around) and clear the history buffer
+        historyIndex = 0;  // Reset to the beginning of history
+
+        // Optionally clear the history buffer or handle how you want to reset the entries
+        // For example, clearing all argumentHistory buffers:
+        for (int i = 0; i < MAX_HISTORY; i++) {
+            for (int idx = 0; idx < MAX_ARGUMENTS; idx++) {
+                argumentHistory[i][idx] = "";
+            }
+            commandHistory[i] = "";
+            fullLineHistory[i] = "";
+        }
+    }
+
+    if (historyIndex >= 0 && historyIndex < MAX_HISTORY) {
         // Clear current input and display the previous/next command from history
-        inputBuffer = commandHistory[historyIndex];
+        inputBuffer.clear(); 
+        command.clear();
+        fullLine.clear();
+        while (!argumentQueue.empty()) {
+            argumentQueue.front();
+            argumentQueue.pop();  
+        }
+
+        fullLine = fullLineHistory[historyIndex];
+        command = commandHistory[historyIndex];
+        for (int idx = 0; idx < argSize[historyIndex]; idx++)  {
+            argumentQueue.push(argumentHistory[historyIndex][idx]);
+        }
+
         UART->print("\r");  // Move the cursor to the beginning of the line
-        for(int len = 0; len < inputBuffer.length() + 5 - 1; len++)
+
+        for(int len = 0; len < 40; len++)
             UART->print(" ");  // Clear the current line (clear any previous characters)
+
+
         UART->print("\r");  // Move back to the beginning of the line
         UART->print("CL> "); 
-        trimSpaces(inputBuffer);
-        UART->print(inputBuffer.c_str());  // Print the command from history
-    }
+        UART->print(fullLine.c_str());  // Print the command from history
+    } 
+
+
 }
 
 // Add a command with its long name, short name, and function pointer

--- a/src/data_handling/LaunchPredictor.cpp
+++ b/src/data_handling/LaunchPredictor.cpp
@@ -1,6 +1,6 @@
 #include "data_handling/LaunchPredictor.h"
 
-#define DEBUG
+// #define DEBUG
 
 #ifdef DEBUG
 #include "ArduinoHAL.h"


### PR DESCRIPTION
## Description
Allows the flight computer to initialize with any UART, including the USB's serial.

### Summary of Changes
- Adds a `Stream * UART` pointer to `commandLine` and it's constructor
- Fixes the missing "CL>" after the first command
- Adds passthrough print functions, so the flight computer can manually send responses when wanted without having to keep track of which Stream is the correct one. 

### Motivation
- Make it easier for a large variety of flight computers to make use of the `commandLine` functionality. 

---

## Testing

Check all that apply:

- [ ] I have added or modified tests to cover these changes.
- [X] I have manually tested the changes on the target device(s) or environment(s).
- [ ] Existing tests were reviewed to ensure they still work as expected.
- [ ] If tests were not added or modified, explain why:
  > (Provide reasoning here)

---

## Building

- [X] This change successfully builds in **at least one** of the following environments:
  - [ ] Native repo
  - [X] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code where necessary for clarity.
- [ ] I have made corresponding updates to documentation (if applicable).
