### PR TITLE
Data Saver SPI Data Dumping + Data Integrity Fixes

### DIFF
--- a/hal/Adafruit_SPIFlash_mock.h
+++ b/hal/Adafruit_SPIFlash_mock.h
@@ -5,6 +5,9 @@
 #include <stddef.h>
 
 #define FAKE_MEMORY_SIZE_BYTES 16777216 // 16MB
+#define SFLASH_SECTOR_SIZE 4096
+#define SFLASH_BLOCK_SIZE 65536
+#define SFLASH_PAGE_SIZE 256
 
 class Adafruit_SPIFlash {
     public:

--- a/hal/ArduinoHAL.h
+++ b/hal/ArduinoHAL.h
@@ -7,6 +7,11 @@
 #include <Adafruit_SPIFlash.h>
 #else // Everything below will only be compiled if we are not on an Arduino
 
+#include <string>
+using String = std::string;
+
+#include <iostream>
+
 #include <chrono>
 
 #include "spi_mock.h"

--- a/hal/DataSaver_mock.h
+++ b/hal/DataSaver_mock.h
@@ -3,7 +3,6 @@
 #include <iostream>
 #include <vector>
 #include <utility>
-#include "unity.h"
 #include "data_handling/DataPoint.h"
 #include "data_handling/DataSaver.h"
 
@@ -35,6 +34,5 @@ class DataSaverMock: public IDataSaver {
                     break;
                 }
             }
-            TEST_ASSERT_TRUE(found);
         }
 };

--- a/hal/serial_mock.h
+++ b/hal/serial_mock.h
@@ -74,6 +74,7 @@ public:
     virtual int peek() { return -1; }
     virtual void flush() {}
     virtual size_t write(uint8_t) { return 0; }
+    virtual size_t write(const char *str) { return 0; }   
     virtual size_t write(const uint8_t *buffer, size_t size) { return size; }
 
     // Read a string until a newline character

--- a/hal/serial_mock.h
+++ b/hal/serial_mock.h
@@ -9,7 +9,6 @@
 #include <string>
 #include <algorithm>
 #include <vector>
-#include "unity.h"
 
 class MockSerial {
 public:
@@ -55,19 +54,6 @@ public:
     // write
     size_t write(uint8_t) { return 0; }
     size_t write(const uint8_t *buffer, size_t size) { return size; }
-
-    // Assertions
-    void assertPrintCalledWith(const std::string& expected) {
-        TEST_ASSERT_TRUE(std::find(printCalls.begin(), printCalls.end(), expected) != printCalls.end());
-    }
-
-    void assertPrintlnCalledWith(const std::string& expected) {
-        TEST_ASSERT_TRUE(std::find(printlnCalls.begin(), printlnCalls.end(), expected) != printlnCalls.end());
-    }
-
-    void assertPrintfCalledWith(const std::string& expected) {
-        TEST_ASSERT_TRUE(std::find(printfCalls.begin(), printfCalls.end(), expected) != printfCalls.end());
-    }
 };
 
 extern MockSerial Serial;

--- a/hal/serial_mock.h
+++ b/hal/serial_mock.h
@@ -86,6 +86,20 @@ public:
         return result;
     }
 
+    template<typename T>
+    void print(const T& message) {
+        std::cout << message;
+    }
+
+    template<typename T>
+    void println(const T& message) {
+        std::cout << message << std::endl;
+    }
+
+    void println() {
+        std::cout << std::endl;
+    }
+
     // Read a string
     std::string readString() {
         std::string result;

--- a/hal/spi_mock.h
+++ b/hal/spi_mock.h
@@ -3,6 +3,7 @@
 
 #include <array>
 #include <cstdint>
+#include <cstddef>
 
 #define MSBFIRST 0
 #define SPI_MODE0 0

--- a/include/UARTCommandHandler.h
+++ b/include/UARTCommandHandler.h
@@ -5,7 +5,7 @@
 #include <queue>
 #include <vector>
 #include <functional>
-#include <HardwareSerial.h>
+#include "ArduinoHAL.h"
 
 #define UART_BUFFER_SIZE 128
 #define MAX_HISTORY      20

--- a/include/data_handling/DataSaverSPI.h
+++ b/include/data_handling/DataSaverSPI.h
@@ -14,6 +14,19 @@
 #define POST_LAUNCH_FLAG_ADDRESS 0x000000  // Address of the post-launch flag
 #define LAUNCH_START_ADDRESS_ADDRESS 0x000001  // Address of the launch start address (32 bits)
 
+
+#pragma pack(push, 1)  // Pack the struct to avoid padding between the name and datas
+typedef struct {
+    uint8_t name;
+    float data;
+} Record_t; 
+
+typedef struct {
+    uint8_t name;
+    uint32_t timestamp_ms;
+} TimestampRecord_t;
+#pragma pack(pop)  // Stop packing from here on out
+
 class DataSaverSPI : public IDataSaver {
 public:
 
@@ -214,6 +227,17 @@ private:
      * @return int   0 on success; non-zero on error
      */
     int addDataToBuffer(const uint8_t* data, size_t length);
+
+
+    // Overloaded functions to add data to the buffer from a Record_t or TimestampRecord_t
+    // More efficient than callling addDataToBuffer with each part of the record
+    int addRecordToBuffer(Record_t * record) {
+        return addDataToBuffer(reinterpret_cast<const uint8_t*>(record), 5);
+    }
+
+    int addRecordToBuffer(TimestampRecord_t * record) {
+        return addDataToBuffer(reinterpret_cast<const uint8_t*>(record), 5);
+    }
 };
 
 #endif // DATA_SAVER_SPI_H

--- a/include/data_handling/DataSaverSPI.h
+++ b/include/data_handling/DataSaverSPI.h
@@ -211,6 +211,14 @@ public:
         return bufferFlushes;
     }
 
+    bool getIsChipFullDueToPostLaunchProtection() const {
+        return isChipFullDueToPostLaunchProtection;
+    }
+
+    bool getRebootedInPostLaunchMode() const {
+        return rebootedInPostLaunchMode;
+    }
+
 private:
 
     /**
@@ -241,6 +249,14 @@ private:
     int addRecordToBuffer(TimestampRecord_t * record) {
         return addDataToBuffer(reinterpret_cast<const uint8_t*>(record), 5);
     }
+
+    // The chip will keep overwriting data forever unless post launch data is being protected.
+    // Once it wraps back around to the launchWriteAddress, it will stop writing data.
+    bool isChipFullDueToPostLaunchProtection;
+
+    // If the fc boots and is already in post launch mode, then do not write to flash
+    // calling clearPostLaunchMode() will allow writing to flash again after a reboot
+    bool rebootedInPostLaunchMode = false;
 };
 
 #endif // DATA_SAVER_SPI_H

--- a/include/data_handling/DataSaverSPI.h
+++ b/include/data_handling/DataSaverSPI.h
@@ -9,10 +9,13 @@
 #include <cstdlib>
 
 
-
+#define METADATA_START_ADDRESS 0x000000  // Start writing metadata at the beginning of the flash
 #define DATA_START_ADDRESS 0x001000  // Start writing data after 1 sector (4kB) of metadata
 #define POST_LAUNCH_FLAG_ADDRESS 0x000000  // Address of the post-launch flag
 #define LAUNCH_START_ADDRESS_ADDRESS 0x000001  // Address of the launch start address (32 bits)
+
+#define POST_LAUNCH_FLAG_TRUE 0x00 // Flag to indicate post-launch mode is active
+#define POST_LAUNCH_FLAG_FALSE 0x01 // Flag to indicate post-launch mode is not active
 
 
 #pragma pack(push, 1)  // Pack the struct to avoid padding between the name and datas

--- a/include/data_handling/SensorDataHandler.h
+++ b/include/data_handling/SensorDataHandler.h
@@ -36,6 +36,10 @@ public:
 
     uint8_t getName() {return name;}
 
+    DataPoint getLastDataPointSaved() const {
+        return lastDataPointSaved;
+    }
+
  
 protected:
     IDataSaver* dataSaver;
@@ -43,6 +47,8 @@ private:
     uint8_t name;
     uint16_t saveInterval_ms; // The minimum time between each data point that is saved to the SD card
     uint32_t lastSaveTime_ms; // The last time a data point was saved to the SD card
+
+    DataPoint lastDataPointSaved;
 };
 
 #endif // DATAHANDLER_H

--- a/include/unity_config.h
+++ b/include/unity_config.h
@@ -1,6 +1,0 @@
-#ifndef UNITY_CONFIG_H
-#define UNITY_CONFIG_H
-
-// Add any Unity configuration settings here
-
-#endif // UNITY_CONFIG_H

--- a/src/data_handling/SensorDataHandler.cpp
+++ b/src/data_handling/SensorDataHandler.cpp
@@ -8,6 +8,7 @@ SensorDataHandler::SensorDataHandler(uint8_t name, IDataSaver* ds) {
     this->dataSaver = ds;
     this->saveInterval_ms = 0;
     this->lastSaveTime_ms = 0;
+    this->lastDataPointSaved = {0, 0};
 }
 
 void SensorDataHandler::restrictSaveSpeed(uint16_t interval_ms){
@@ -20,6 +21,7 @@ int SensorDataHandler::addData(DataPoint data){
     if (data.timestamp_ms - lastSaveTime_ms > saveInterval_ms){
         dataSaver->saveDataPoint(data, name);
         lastSaveTime_ms = data.timestamp_ms;
+        lastDataPointSaved = data;
     }
 
     return 0;


### PR DESCRIPTION
## Description
Revamps the data saver SPI dumping function. Aligns the saving buffer to 256-byte pages, improving speed.

### Summary of Changes
- Expands the SPI and Serial mocks
- Removes Unity from all mocks
- Improve post-launch mode handling of the data saver
- Fix data dumping

### Motivation
Allows MARTHA 1.3, which uses a flash chip connected to SPI, to save and dump data successfully. 


---

## Testing

Check all that apply:

- [X] I have added or modified tests to cover these changes.
- [X] I have manually tested the changes on the target device(s) or environment(s).
- [X] Existing tests were reviewed to ensure they still work as expected.
- [ ] If tests were not added or modified, explain why:
  > (Provide reasoning here)

---

## Building

- [X] This change successfully builds in **at least one** of the following environments:
  - [X] Native repo
  - [X] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code where necessary for clarity.
- [X] I have made corresponding updates to documentation (if applicable).
