### PR TITLE
Add April 2025 flights to flight tests doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Avionics for Clemson University Rocket Engineering
 
-**Avionics** is an Arduino-Core based system designed for high reliability and efficiency, serving as the backbone for multiple flight computers in the Clemson University Rocket Engineering program.
+Avionics is a modular, Arduino-core based system powering the flight computers of Clemson University Rocket Engineering. Designed for high reliability and efficiency, it supports real-time state estimation, data logging, and robust communication.
 
 ## Table of Contents
 
@@ -13,22 +13,31 @@
 
 ## Introduction
 
-This repository contains the avionics system used across various flight computers within the Clemson University Rocket Engineering program. Designed to be modular and highly configurable, the system supports critical functions such as state detection, data logging, and robust communication.
+This repository contains the avionics system used across various flight computers within the Clemson University Rocket Engineering organization. Designed to be modular and highly configurable, the system supports critical functions such as state detection, data logging, and robust communication.
 
 ## Features
 
-### State Detection
+### State Detection Tools
 
 - **Launch Detection:**  
   The [Launch Detector](include/data_handling/LaunchDetector.h) uses a rolling median of acceleration data to accurately detect launches. It is highly configurable to accommodate different launch profiles and includes stringent data rate and error-handling mechanisms.
 
-- **Kalman Filter:**  
-  The [Kalman Filter](include/kf-2d.h) module fuses accelerometer and altimeter data to provide precise estimates of vertical velocity.
+- **Vertical Velocity Estimation:**  
+  The [Vertical Velocity Estimator](include/state_estimation/VerticalVelocityEstimator.h) employs a 1D Kalman filter to estimate vertical velocity from acceleration and altitude data.
+
+- **Apogee Detection:**  
+  The [Apogee Detector](include/state_estimation/ApogeeDetector.h) utilizes the vertical velocity estimator to detect when the rocket begins to fall. Also checks if the altitude has dropped by a certain threshold from the highest recorded altitude.
+
+- **Apogee Prediction:**  
+  The [Apogee Predictor](include/state_estimation/ApogeePredictor.h) utilizes the vertical velocity estimator to predict the time until apogee and the maximum altitude.
 
 ### Data Logging
 
-- **SPI Flash-based Logging:**  
+- **SPI Embedded Flash-based Logging:**  
   [DataSaverSPI](include/data_handling/DataSaverSPI.h) logs sensor data directly to any W25 SPI flash chip. Each sensor logs data at its own rate using the "Byte5" format, which is optimized for space efficiency while allowing for unordered data. Data is stored in a circular buffer until post-launch mode is activated.
+
+- **SPI SD Card-based Logging:**  
+  [DataSaverBigSD](include/data_handling/DataSaverBigSD.h) logs data to a large capacity SD card. Data is saved in a stream with less regard for space efficiency. Saves data in a stream format rather than a CSV. 
 
 - **Serial-based Logging:**  
   [DataSaverSDSerial](include/data_handling/DataSaverSDSerial.h) provides an alternative logging mechanism by streaming binary data to a serial interface. Although less space-efficient than "Byte5", it is designed for applications with large SD cards. Refer to the [Serial-Logger-Decoding](https://github.com/CURocketEngineering/Serial-Logger-Decoding) repository for decoding instructions.
@@ -37,9 +46,6 @@ This repository contains the avionics system used across various flight computer
 
 - **Serial Command Handler:**  
   The [UARTCommandHandler](include/UARTCommandHandler.h) offers a fully configurable command interface for runtime configuration, debugging, and data retrieval, using function pointers for flexibility.
-
-- **CC1125 Transceiver:**  
-  The [CC1125](include/CC1125.h) module enables direct communication via an embedded CC1125 transceiver over SPI.
 
 ## Dependent Systems
 
@@ -58,22 +64,7 @@ Unit tests are managed by the [Native](https://github.com/CURocketEngineering/Na
 
 ### Flight Tests
 
-The following rocket flights have successfully utilized this avionics system (most recent first):
-
-- **[MARTHA 1.3 Mar 8th 2025 L1 Cert Launches](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.1):**
-The MARTHA 1.3 system successfully completed its first altitude data collection and apogee detection. Two separate MARTHA 1.3 boards, B1 and B2, were flown on different rockets, each accurately detecting both launch and apogee.
-For this test, MARTHA was used exclusively for data collection, while parachute deployment was handled by a Stratologger. Notably, B1’s rocket did not experience a deployment event, whereas B2’s rocket did. Since both units successfully detected apogee regardless of deployment status, we can confidently conclude that MARTHA’s apogee detection operates independently of the Stratologger's deployment event.
- 
-
-- **[MARTHA 1.3 Feb 8th 2025 Test Vehicle Launch Attempt](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.0):**
- MARTHA was mounted to the Active Aero test vehicle, but it never launched (wasn't fully assembled in time). Data was collected for 14.18 hours before the 9V battery died. The data was successfully dumped, and the last hour of data before shutdown was recorded. A consistent 100Hz loop speed was achieved. During a rough assembly, the LaunchDetector never had a false positive, even though it detected large acceleration values.
-
-
-- **[MARTHA 1.1 Nov 9th L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.1.0):**  
-  Launch detection and SD card data logging performed as expected. Note: No altitude data was recorded due to issues with sensor drivers or hardware damage.
-
-- **[MARTHA 1.1 Spaceport 2024](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.0.0):**  
-  Although data was captured via the serial logger, the battery failure on the pad resulted in no launch data being recorded.
+See all of our flights using this software at [Flight Tests](docs/FlightTests.md).
 
 ## License
 

--- a/docs/FlightTests.md
+++ b/docs/FlightTests.md
@@ -1,0 +1,46 @@
+# Flight Test History
+
+## Flight Number Key
+(rocket type)-(flight compute type)-(month)-(day)-(year)-(flight number)
+
+### Rocket Types
+- **L1** - Level 1 Certification
+- **L2** - Level 2 Certification
+- **L3** - Level 3 Certification
+- **AA** - Active Aero
+- **CV** - Competition Vehicle
+
+### Flight Computer Types
+- **MA** - MARTHA (Miniaturized Avionics for Rapid Testing Handling and Assessment)
+- **JM** - JEM (Just an Expanded MARTHA)
+- **AA** - Active Aero flight computer (responsible for brake deployment)
+
+## Flight Test History (Most recent first)
+
+- **AA-AA-04-13-2025-0 [Active Aero FC Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/Active-Aero/releases/tag/1.0):**
+  Flew on the same flight as **AA-MA-04-13-2025-0** and was connected to the air brakes. It successfully detected launch, engine burnout, and apogee (based on post-fight data analysis). The brakes were accurately deployed at 1 second after engine burnout and retracted 3 seconds before apogee (according to the software). There is no way of knowing if the fins actually deployed and then retracted or never deployed in the first place. Utilized the new SD card data saver which worked well. 
+
+
+- **AA-MA-04-13-2025-0 [MARTHA 1.3 Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.1.0):**
+  MARTHA 1.3 Board 1 (B1) was flown the Active Aero vehicle to around 3800 feet. It detected launch and apogee successfully. It also performed live apogee prediction which had poor performance (tended to underestimate throughout the entire flight). All data was recovered successfully. Only the drogue chute deployed but MARTHA survived the hard landing. 
+
+- **L1-MA-04-12-2025-0 [MARTHA 1.3 Apr 12th 2025 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.2-no-alt):**  
+  Flight **L1-MA-04-12-2025-0**.  
+  MARTHA 1.3 Board 3 (B3) flew on an L1 cert. It successfully collected all data metrics except for altimeter data due to B3 having a malfunctioning altimeter. It ran a custom version of MARTHA software with the altimeter collection calls commented out. The parachute deployed partially, but B3 survived the hard landing. Launch detection was successful; apogee detection failed due to lack of altitude data.
+
+- **L1-MA-03-08-2025-0 [MARTHA 1.3 Mar 8th 2025 L1 Cert Launches](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.1):**  
+  Flight **L1-MA-03-08-2025-0**.  
+  The MARTHA 1.3 system successfully completed its first altitude data collection and apogee detection. Two separate MARTHA 1.3 boards, B1 and B2, were flown on different rockets, each accurately detecting both launch and apogee. MARTHA was used solely for data collection; parachute deployment was managed by a Stratologger. Notably, B1’s rocket did not experience a deployment event, whereas B2’s did, demonstrating that MARTHA’s apogee detection is independent of Stratologger deployment.
+
+- **AA-MA-02-08-2025-0 [MARTHA 1.3 Feb 8th 2025 Test Vehicle Launch Attempt](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.0):**  
+  Flight **AA-MA-02-08-2025-0**.  
+  MARTHA was mounted to the Active Aero test vehicle, but the vehicle never launched due to incomplete assembly. MARTHA collected data for 14.18 hours before the 9V battery expired. Data was successfully dumped, and the last hour before shutdown was recorded. A consistent 100Hz loop speed was achieved, and despite large accelerations during rough handling, the LaunchDetector showed no false positives.
+
+- **L1-MA-11-09-2024-0 [MARTHA 1.1 Nov 9th 2024 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.1.0):**  
+  Flight **L1-MA-11-09-2024-0**.  
+  Launch detection and SD card data logging performed as expected. No altitude data was recorded, likely due to issues with sensor drivers or hardware damage.
+
+- **CV-MA-06-22-2024-0 [MARTHA 1.1 Spaceport 2024](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.0.0):**  
+  Flight **CV-MA-06-22-2024-0**.  
+  Although data was captured via the serial logger, a battery failure on the pad resulted in no launch data being recorded. The log from being the pad for 6 hours was only 30 minutes long.
+

--- a/docs/FlightTests.md
+++ b/docs/FlightTests.md
@@ -17,30 +17,25 @@
 
 ## Flight Test History (Most recent first)
 
-- **AA-AA-04-13-2025-0 [Active Aero FC Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/Active-Aero/releases/tag/1.0):**
-  Flew on the same flight as **AA-MA-04-13-2025-0** and was connected to the air brakes. It successfully detected launch, engine burnout, and apogee (based on post-fight data analysis). The brakes were accurately deployed at 1 second after engine burnout and retracted 3 seconds before apogee (according to the software). There is no way of knowing if the fins actually deployed and then retracted or never deployed in the first place. Utilized the new SD card data saver which worked well. 
+- **AA-AA-04-13-2025-0 [Active Aero FC Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/Active-Aero/releases/tag/1.0):**  
+  Flew on the same flight as **AA-MA-04-13-2025-0** and was connected to the air brakes. It successfully detected launch, engine burnout, and apogee (based on post-fight data analysis). The brakes were accurately deployed at 1 second after engine burnout and retracted 3 seconds before apogee (according to the software). There is no way of knowing if the fins actually deployed and then retracted or never deployed in the first place. Utilized the [new SD card data saver](include/data_handling/DataSaverBigSD.h) which worked well. 
 
 
-- **AA-MA-04-13-2025-0 [MARTHA 1.3 Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.1.0):**
+- **AA-MA-04-13-2025-0 [MARTHA 1.3 Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.1.0):**  
   MARTHA 1.3 Board 1 (B1) was flown the Active Aero vehicle to around 3800 feet. It detected launch and apogee successfully. It also performed live apogee prediction which had poor performance (tended to underestimate throughout the entire flight). All data was recovered successfully. Only the drogue chute deployed but MARTHA survived the hard landing. 
 
 - **L1-MA-04-12-2025-0 [MARTHA 1.3 Apr 12th 2025 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.2-no-alt):**  
-  Flight **L1-MA-04-12-2025-0**.  
   MARTHA 1.3 Board 3 (B3) flew on an L1 cert. It successfully collected all data metrics except for altimeter data due to B3 having a malfunctioning altimeter. It ran a custom version of MARTHA software with the altimeter collection calls commented out. The parachute deployed partially, but B3 survived the hard landing. Launch detection was successful; apogee detection failed due to lack of altitude data.
 
 - **L1-MA-03-08-2025-0 [MARTHA 1.3 Mar 8th 2025 L1 Cert Launches](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.1):**  
-  Flight **L1-MA-03-08-2025-0**.  
   The MARTHA 1.3 system successfully completed its first altitude data collection and apogee detection. Two separate MARTHA 1.3 boards, B1 and B2, were flown on different rockets, each accurately detecting both launch and apogee. MARTHA was used solely for data collection; parachute deployment was managed by a Stratologger. Notably, B1’s rocket did not experience a deployment event, whereas B2’s did, demonstrating that MARTHA’s apogee detection is independent of Stratologger deployment.
 
 - **AA-MA-02-08-2025-0 [MARTHA 1.3 Feb 8th 2025 Test Vehicle Launch Attempt](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.0):**  
-  Flight **AA-MA-02-08-2025-0**.  
   MARTHA was mounted to the Active Aero test vehicle, but the vehicle never launched due to incomplete assembly. MARTHA collected data for 14.18 hours before the 9V battery expired. Data was successfully dumped, and the last hour before shutdown was recorded. A consistent 100Hz loop speed was achieved, and despite large accelerations during rough handling, the LaunchDetector showed no false positives.
 
 - **L1-MA-11-09-2024-0 [MARTHA 1.1 Nov 9th 2024 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.1.0):**  
-  Flight **L1-MA-11-09-2024-0**.  
   Launch detection and SD card data logging performed as expected. No altitude data was recorded, likely due to issues with sensor drivers or hardware damage.
 
 - **CV-MA-06-22-2024-0 [MARTHA 1.1 Spaceport 2024](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.0.0):**  
-  Flight **CV-MA-06-22-2024-0**.  
   Although data was captured via the serial logger, a battery failure on the pad resulted in no launch data being recorded. The log from being the pad for 6 hours was only 30 minutes long.
 

--- a/docs/FlightTests.md
+++ b/docs/FlightTests.md
@@ -18,7 +18,7 @@
 ## Flight Test History (Most recent first)
 
 - **AA-AA-04-13-2025-0 [Active Aero FC Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/Active-Aero/releases/tag/1.0):**  
-  Flew on the same flight as **AA-MA-04-13-2025-0** and was connected to the air brakes. It successfully detected launch, engine burnout, and apogee (based on post-fight data analysis). The brakes were accurately deployed at 1 second after engine burnout and retracted 3 seconds before apogee (according to the software). There is no way of knowing if the fins actually deployed and then retracted or never deployed in the first place. Utilized the [new SD card data saver](include/data_handling/DataSaverBigSD.h) which worked well. 
+  Flew on the same flight as **AA-MA-04-13-2025-0** and was connected to the air brakes. It successfully detected launch, engine burnout, and apogee (based on post-fight data analysis). The brakes were accurately deployed at 1 second after engine burnout and retracted 3 seconds before apogee (according to the software). There is no way of knowing if the fins actually deployed and then retracted or never deployed in the first place. Utilized the [new SD card data saver](../include/data_handling/DataSaverBigSD.h) which worked well. 
 
 
 - **AA-MA-04-13-2025-0 [MARTHA 1.3 Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.1.0):**  

--- a/docs/FlightTests.md
+++ b/docs/FlightTests.md
@@ -1,41 +1,47 @@
 # Flight Test History
 
-## Flight Number Key
-(rocket type)-(flight compute type)-(month)-(day)-(year)-(flight number)
+## Flight-Number Format  
+`<rocket type>-<flight computer type>-<year>-<month>-<day>-<index>`
+
+The trailing **index** (`0`, `1`, …) distinguishes multiple flights of the **same rocket / flight-computer pair on the same day**.
 
 ### Rocket Types
-- **L1** - Level 1 Certification
-- **L2** - Level 2 Certification
-- **L3** - Level 3 Certification
-- **AA** - Active Aero
-- **CV** - Competition Vehicle
+| Code | Description                |
+|------|----------------------------|
+| **L1** | Level 1 Certification |
+| **L2** | Level 2 Certification |
+| **L3** | Level 3 Certification |
+| **AA** | Active Aero            |
+| **CV** | Competition Vehicle    |
 
-### Flight Computer Types
-- **MA** - MARTHA (Miniaturized Avionics for Rapid Testing Handling and Assessment)
-- **JM** - JEM (Just an Expanded MARTHA)
-- **AA** - Active Aero flight computer (responsible for brake deployment)
+### Flight-Computer Types
+| Code | Description |
+|------|-------------|
+| **MA** | MARTHA (Miniaturized Avionics for Rapid Testing Handling and Assessment) |
+| **JM** | JEM (Just an Expanded MARTHA) |
+| **AA** | Active Aero flight computer (air-brake deployment) |
 
-## Flight Test History (Most recent first)
+---
 
-- **AA-AA-04-13-2025-0 [Active Aero FC Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/Active-Aero/releases/tag/1.0):**  
+## Flight Test History (most recent first)
+
+- **AA-AA-2025-04-13-0 [Active Aero FC Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/Active-Aero/releases/tag/1.0):**  
   Flew on the same flight as **AA-MA-04-13-2025-0** and was connected to the air brakes. It successfully detected launch, engine burnout, and apogee (based on post-fight data analysis). The brakes were accurately deployed at 1 second after engine burnout and retracted 3 seconds before apogee (according to the software). There is no way of knowing if the fins actually deployed and then retracted or never deployed in the first place. Utilized the [new SD card data saver](../include/data_handling/DataSaverBigSD.h) which worked well. 
 
-
-- **AA-MA-04-13-2025-0 [MARTHA 1.3 Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.1.0):**  
+- **AA-MA-2025-04-13-0 [MARTHA 1.3 Apr 13th 2025 Active Aero Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.1.0):**  
   MARTHA 1.3 Board 1 (B1) was flown the Active Aero vehicle to around 3800 feet. It detected launch and apogee successfully. It also performed live apogee prediction which had poor performance (tended to underestimate throughout the entire flight). All data was recovered successfully. Only the drogue chute deployed but MARTHA survived the hard landing. 
 
-- **L1-MA-04-12-2025-0 [MARTHA 1.3 Apr 12th 2025 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.2-no-alt):**  
+- **L1-MA-2025-04-12-0 [MARTHA 1.3 Apr 12th 2025 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.2-no-alt):**  
   MARTHA 1.3 Board 3 (B3) flew on an L1 cert. It successfully collected all data metrics except for altimeter data due to B3 having a malfunctioning altimeter. It ran a custom version of MARTHA software with the altimeter collection calls commented out. The parachute deployed partially, but B3 survived the hard landing. Launch detection was successful; apogee detection failed due to lack of altitude data.
 
-- **L1-MA-03-08-2025-0 [MARTHA 1.3 Mar 8th 2025 L1 Cert Launches](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.1):**  
+- **L1-MA-2025-03-08-0 [MARTHA 1.3 Mar 8th 2025 L1 Cert Launches](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.1):**  
   The MARTHA 1.3 system successfully completed its first altitude data collection and apogee detection. Two separate MARTHA 1.3 boards, B1 and B2, were flown on different rockets, each accurately detecting both launch and apogee. MARTHA was used solely for data collection; parachute deployment was managed by a Stratologger. Notably, B1’s rocket did not experience a deployment event, whereas B2’s did, demonstrating that MARTHA’s apogee detection is independent of Stratologger deployment.
 
-- **AA-MA-02-08-2025-0 [MARTHA 1.3 Feb 8th 2025 Test Vehicle Launch Attempt](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.0):**  
+- **AA-MA-2025-02-08-0 [MARTHA 1.3 Feb 8th 2025 Test Vehicle Launch Attempt](https://github.com/CURocketEngineering/MARTHA-1.3/releases/tag/1.0.0):**  
   MARTHA was mounted to the Active Aero test vehicle, but the vehicle never launched due to incomplete assembly. MARTHA collected data for 14.18 hours before the 9V battery expired. Data was successfully dumped, and the last hour before shutdown was recorded. A consistent 100Hz loop speed was achieved, and despite large accelerations during rough handling, the LaunchDetector showed no false positives.
 
-- **L1-MA-11-09-2024-0 [MARTHA 1.1 Nov 9th 2024 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.1.0):**  
+- **L1-MA-2024-11-09-0 [MARTHA 1.1 Nov 9th 2024 L1 Cert Launch](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.1.0):**  
   Launch detection and SD card data logging performed as expected. No altitude data was recorded, likely due to issues with sensor drivers or hardware damage.
 
-- **CV-MA-06-22-2024-0 [MARTHA 1.1 Spaceport 2024](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.0.0):**  
+- **CV-MA-2024-06-22-0 [MARTHA 1.1 Spaceport 2024](https://github.com/CURocketEngineering/MARTHA-1.1/releases/tag/v1.0.0):**  
   Although data was captured via the serial logger, a battery failure on the pad resulted in no launch data being recorded. The log from being the pad for 6 hours was only 30 minutes long.
-


### PR DESCRIPTION
## Description

Adds April flights to the Avionics documentation 

### Summary of Changes
- Adds 3 launches to the flight tests (AA-AA-04-13-2025-0, AA-MA-04-13-2025-0, L1-MA-04-12-2025-0) 
- Moves flight tests to a separate markdown file
- Updates the README with the new data saver and state estimation tools. 

### Motivation
- Important to keep our documentation up to date 

---

## Testing

Check all that apply:

- [ ] I have added or modified tests to cover these changes.
- [ ] I have manually tested the changes on the target device(s) or environment(s).
- [ ] Existing tests were reviewed to ensure they still work as expected.
- [X] If tests were not added or modified, explain why:
  > Only markdown files were changed

---

## Building

- [ ] This change successfully builds in **at least one** of the following environments:
  - [ ] Native repo
  - [ ] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary for clarity.
- [X] I have made corresponding updates to documentation (if applicable).
