### PR TITLE
feat: improve data injection reliability with 3 byte ack

### DIFF
--- a/include/simulation/Serial_Sim.h
+++ b/include/simulation/Serial_Sim.h
@@ -160,10 +160,13 @@ private:
         return value;
     }
 
-    // Send ACK (0x06) alongside the current state to the serial port
+    // Send ACK alongside the current state to the serial port
     void ack(){
         serial->write(stateMachine->getState());
-        serial->write(0x06);
+        // Ack will be a series of 0xaa, 0xbb, 0xcc
+        serial->write(0xaa);
+        serial->write(0xbb);
+        serial->write(0xcc);
     }
 
 private:

--- a/include/simulation/simulation_requirements.txt
+++ b/include/simulation/simulation_requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+pyserial
+pandas

--- a/include/state_estimation/States.h
+++ b/include/state_estimation/States.h
@@ -10,16 +10,16 @@
 // apogee is an event that causes a transition from STATE_ASCENT to STATE_DESCENT, but it is not a state itself.
 // The state machines are in charge of detecting these transitions and updating the states. 
 enum FlightState {
-    STATE_UNARMED,
-    STATE_ARMED,
-    STATE_SOFT_ASCENT,
-    STATE_ASCENT, // Don't use the ascent state if you are already using powered ascent and coast ascent
-    STATE_POWERED_ASCENT,
-    STATE_COAST_ASCENT,
-    STATE_DESCENT,
-    STATE_DROGUE_DEPLOYED,
-    STATE_MAIN_DEPLOYED,
-    STATE_LANDED,
+    STATE_UNARMED, // 0x00
+    STATE_ARMED, // 0x01
+    STATE_SOFT_ASCENT, // 0x02
+    STATE_ASCENT, // 0x03 Don't use the ascent state if you are already using powered ascent and coast ascent
+    STATE_POWERED_ASCENT, // 0x04
+    STATE_COAST_ASCENT, // 0x05
+    STATE_DESCENT, // 0x06
+    STATE_DROGUE_DEPLOYED, // 0x07
+    STATE_MAIN_DEPLOYED, // 0x08
+    STATE_LANDED, // 0x09
 };
 
 #endif

--- a/src/state_estimation/StateMachine.cpp
+++ b/src/state_estimation/StateMachine.cpp
@@ -46,7 +46,9 @@ int StateMachine::update(const AccelerationTriplet& accel, const DataPoint& alt)
                 // Put the data saver into post-launch mode
                 dataSaver->launchDetected(fastLaunchDetector->getLaunchedTime());
             }
-            else if (launchDetector->isLaunched()) {
+            
+            // The FLD should always trigger before the LP, but we check for LP launch just in case
+            if (launchDetector->isLaunched()) {
                 // Change state to ascent
                 state = STATE_ASCENT;
 


### PR DESCRIPTION
## Description
Make data injection test better

### Summary of Changes
- 3 byte ACK instead of single byte which had reliability issues with state 0x06
- Add python requirements file for running simulation.py
- Make the targeted port a command line argument

### Motivation
- Testing wasn't running consistently, now it is

---

## Testing

Check all that apply:

- [ ] I have added or modified tests to cover these changes.
- [X] I have manually tested the changes on the target device(s) or environment(s).
- [ ] Existing tests were reviewed to ensure they still work as expected.
- [ ] If tests were not added or modified, explain why:
  > (Provide reasoning here)

---

## Building

- [X] This change successfully builds in **at least one** of the following environments:
  - [ ] Native repo
  - [X] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary for clarity.
- [ ] I have made corresponding updates to documentation (if applicable).
