### PR TITLE
Fix Data saver behavior with FLD

### DIFF
--- a/src/data_handling/DataSaverSPI.cpp
+++ b/src/data_handling/DataSaverSPI.cpp
@@ -133,6 +133,8 @@ void DataSaverSPI::clearPostLaunchMode() {
     
     uint8_t flag = POST_LAUNCH_FLAG_FALSE;
     flash->writeBuffer(POST_LAUNCH_FLAG_ADDRESS, &flag, sizeof(flag));
+
+    postLaunchMode = false;
 }
 
 void DataSaverSPI::dumpData(Stream &serial, bool ignoreEmptyPages) { //NOLINT(readability-function-cognitive-complexity)


### PR DESCRIPTION
## Description

### Summary of Changes
- removes clearInternalState() from clearPostLaunchMode() in DataSaverSPI to fix data saving behavior

### Motivation
- (Provide a brief explanation of why these changes are necessary)

---

## Testing

Check all that apply:

- [ ] I have added or modified tests to cover these changes.
- [ X ] I have manually tested the changes on the target device(s) or environment(s).
- [ X ] Existing tests were reviewed to ensure they still work as expected.
- [ ] If tests were not added or modified, explain why:
  > (Provide reasoning here)

---

## Building

- [ ] This change successfully builds in **at least one** of the following environments:
  - [ X ] Native repo
  - [ x ] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary for clarity.
- [ ] I have made corresponding updates to documentation (if applicable).
