### PR TITLE
fix: return carriage handling

### DIFF
--- a/src/UARTCommandHandler.cpp
+++ b/src/UARTCommandHandler.cpp
@@ -55,15 +55,17 @@ void CommandLine::readInput() { // NOLINT(readability-function-cognitive-complex
         const char receivedChar = static_cast<char>(UART->read());
 
         if (isBackspace_(receivedChar)) {
+            lastWasCR_ = false;
             handleBackspace_();
         } else if (isNewline_(receivedChar)) {
-            if (lastWasCR_){
-                lastWasCR_ = false; // Handle \r\n by ignoring the \n
+            if (lastWasCR_ && receivedChar == '\n') {
+                lastWasCR_ = false; // Treat CRLF as a single newline event.
                 continue;
             }
             lastWasCR_ = (receivedChar == '\r');
             handleNewline_();
         } else {
+            lastWasCR_ = false;
             handleChar_(receivedChar);
         }
     }


### PR DESCRIPTION
## Description

### Summary of Changes
- Properly utilizes the \r ignore by checking for a \r followed by a \n

### Motivation
- Eliminates an issue on some terminal where you have to press enter twice. 

---

## Testing

Check all that apply:

- [ ] I have added or modified tests to cover these changes.
- [ ] I have manually tested the changes on the target device(s) or environment(s).
- [ ] Existing tests were reviewed to ensure they still work as expected.
- [ ] If tests were not added or modified, explain why:
  > (Provide reasoning here)

---

## Building

- [ ] This change successfully builds in **at least one** of the following environments:
  - [ ] Native repo
  - [X] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary for clarity.
- [ ] I have made corresponding updates to documentation (if applicable).
