### PR TITLE
Fixed VVE that is a duplicate time stamps occurs it returns and added a new prediction method for apogee(simulate)

### DIFF
--- a/include/state_estimation/ApogeePredictor.h
+++ b/include/state_estimation/ApogeePredictor.h
@@ -45,6 +45,8 @@ public:
 
     void analytic_update();
 
+     void simulate_update();
+
     // ----- Accessors -----
     [[nodiscard]] bool     isPredictionValid()            const;
     [[nodiscard]] float    getTimeToApogee_s()            const;
@@ -66,7 +68,12 @@ private:
     float    tToApogee_;    ///< Time until apogee (seconds)
     uint32_t predApogeeTs_; ///< Timestamp of predicted apogee (ms)
     float    predApogeeAlt_;///< Predicted altitude at apogee (m)
-    float currentDragCoefficient = 0.0025F;     ///< Drag coefficient
+    float currentDragCoefficient = 0.0005F;     ///< Drag coefficient
+    
+    //variables for simulation apogee prediction
+    float beta_ = 400.0f;
+    float filteredApogee_ = 0.0f;
+    bool apogeeInitialized_ = false;
 
     // Bookkeeping
     uint32_t lastTs_;       ///< Last timestamp received

--- a/include/state_estimation/ApogeePredictor.h
+++ b/include/state_estimation/ApogeePredictor.h
@@ -45,7 +45,7 @@ public:
 
     void analytic_update();
 
-     void simulate_update();
+    void simulate_update();
 
     // ----- Accessors -----
     [[nodiscard]] bool     isPredictionValid()            const;

--- a/src/state_estimation/ApogeePredictor.cpp
+++ b/src/state_estimation/ApogeePredictor.cpp
@@ -190,7 +190,6 @@ void ApogeePredictor::analytic_update()
     const float kApogeeFactor = 0.5F;
     const float kBallisticDenominator = 2.0F;
 
-
     //if the velocity is less than or equal to zero, the rocket has already reach apogee and the apogee is the current altitude
     if (velocity <= 0.0F)
     {
@@ -230,6 +229,68 @@ const float kMeasured = -(acceleration + gravity) /
     }
 
     predApogeeAlt_ = apogee;
+    valid_ = true;
+}
+
+
+void ApogeePredictor::simulate_update()
+{
+    const float g = 9.80665F;
+
+    float velocity = vve_.getEstimatedVelocity();
+    float altitude = vve_.getEstimatedAltitude();
+    float accel = vve_.getInertialVerticalAcceleration();
+
+    const float kVelocityEpsilon = 0.001F;
+    const float kMinVelocityForDrag = 15.0F;
+
+    // Already descending
+    if (velocity <= 0.0F)
+    {
+        predApogeeAlt_ = altitude;
+        valid_ = true;
+        return;
+    }
+
+    // Only update drag during ballistic phase
+    if (velocity > kMinVelocityForDrag)
+    {
+        float kMeasured =
+            -(accel + g) / (velocity * velocity + kVelocityEpsilon);
+
+        if (kMeasured > 0.0F && kMeasured < 0.05F)
+        {
+            const float alpha = 0.05F; // slow filter
+            currentDragCoefficient =
+                (1.0F - alpha) * currentDragCoefficient +
+                alpha * kMeasured;
+        }
+    }
+
+    // -------- Forward simulate trajectory --------
+
+    float simAltitude = altitude;
+    
+    float simVelocity = velocity;
+
+    const float dt = 0.02F;   // 50 Hz integration
+    const int maxSteps = 500; // safety
+
+    for (int i = 0; i < maxSteps; i++)
+    {
+        float dragAccel =
+            currentDragCoefficient * simVelocity * simVelocity;
+
+        float a = -g - dragAccel;
+
+        simVelocity += a * dt;
+        simAltitude += simVelocity * dt;
+
+        if (simVelocity <= 0.0F)
+            break;
+    }
+
+    predApogeeAlt_ = simAltitude;
     valid_ = true;
 }
 

--- a/src/state_estimation/ApogeePredictor.cpp
+++ b/src/state_estimation/ApogeePredictor.cpp
@@ -235,59 +235,57 @@ const float kMeasured = -(acceleration + gravity) /
 
 void ApogeePredictor::simulate_update()
 {
-    const float g = 9.80665F;
+    const float kGravity = 9.80665F;
 
-    float velocity = vve_.getEstimatedVelocity();
-    float altitude = vve_.getEstimatedAltitude();
-    float accel = vve_.getInertialVerticalAcceleration();
+    const float estimatedVelocity = vve_.getEstimatedVelocity();
+    const float estimatedAltitude = vve_.getEstimatedAltitude();
+    const float inertialAccel = vve_.getInertialVerticalAcceleration();
 
     const float kVelocityEpsilon = 0.001F;
     const float kMinVelocityForDrag = 15.0F;
+    const float kAlpha = 0.05F;           // slow filter constant
+    const float kMaxDragCoefficient = 0.05F;
+    const float kDt = 0.01F;              // simulation time step
+    const int kMaxSimSteps = 500;         // safety limit
 
     // Already descending
-    if (velocity <= 0.0F)
+    if (estimatedVelocity <= 0.0F)
     {
-        predApogeeAlt_ = altitude;
+        predApogeeAlt_ = estimatedAltitude;
         valid_ = true;
         return;
     }
 
     // Only update drag during ballistic phase
-    if (velocity > kMinVelocityForDrag)
+    if (estimatedVelocity > kMinVelocityForDrag)
     {
-        float kMeasured =
-            -(accel + g) / (velocity * velocity + kVelocityEpsilon);
+        const float measuredDrag =
+            -(inertialAccel + kGravity) / (estimatedVelocity * estimatedVelocity + kVelocityEpsilon);
 
-        if (kMeasured > 0.0F && kMeasured < 0.05F)
+        if (measuredDrag > 0.0F && measuredDrag < kMaxDragCoefficient)
         {
-            const float alpha = 0.05F; // slow filter
             currentDragCoefficient =
-                (1.0F - alpha) * currentDragCoefficient +
-                alpha * kMeasured;
+                (1.0F - kAlpha) * currentDragCoefficient +
+                kAlpha * measuredDrag;
         }
     }
 
     // -------- Forward simulate trajectory --------
+    float simAltitude = estimatedAltitude;
+    float simVelocity = estimatedVelocity;
 
-    float simAltitude = altitude;
-    
-    float simVelocity = velocity;
-
-    const float dt = 0.02F;   // 50 Hz integration
-    const int maxSteps = 500; // safety
-
-    for (int i = 0; i < maxSteps; i++)
+    for (int step = 0; step < kMaxSimSteps; step++)
     {
-        float dragAccel =
-            currentDragCoefficient * simVelocity * simVelocity;
+        const float dragAcceleration = currentDragCoefficient * simVelocity * simVelocity;
+        const float totalAcceleration = -kGravity - dragAcceleration;
 
-        float a = -g - dragAccel;
-
-        simVelocity += a * dt;
-        simAltitude += simVelocity * dt;
+        simVelocity += totalAcceleration * kDt;
+        simAltitude += simVelocity * kDt;
 
         if (simVelocity <= 0.0F)
+        {
             break;
+        }
     }
 
     predApogeeAlt_ = simAltitude;

--- a/src/state_estimation/ApogeePredictor.cpp
+++ b/src/state_estimation/ApogeePredictor.cpp
@@ -256,7 +256,7 @@ void ApogeePredictor::simulate_update()
         return;
     }
 
-    // Only update drag during ballistic phase
+    // Only update drag during cost phase
     if (estimatedVelocity > kMinVelocityForDrag)
     {
         const float measuredDrag =

--- a/src/state_estimation/VerticalVelocityEstimator.cpp
+++ b/src/state_estimation/VerticalVelocityEstimator.cpp
@@ -79,7 +79,7 @@ void VerticalVelocityEstimator::update(const AccelerationTriplet &accel, const D
 
 
 
-    // checks the time stamps for both altitude and acceleration timestamps
+    // Ensures the data is newer than the previous data and that is not the same as the last data
     if (currentTimestamp_ms <= lastTimestamp_ms)
     {
         return;

--- a/src/state_estimation/VerticalVelocityEstimator.cpp
+++ b/src/state_estimation/VerticalVelocityEstimator.cpp
@@ -75,10 +75,22 @@ void VerticalVelocityEstimator::update(const AccelerationTriplet &accel, const D
         verticalAxisDetermined = true;
     }
 
-    // Compute time step in seconds (dt). Use a small default if timestamps are identical.
-    const float dt = (currentTimestamp_ms > lastTimestamp_ms)
-               ? (static_cast<float>(currentTimestamp_ms - lastTimestamp_ms)) * MILLISECONDS_TO_SECONDS
-               : MINIMUM_DELTA_T_S;
+
+
+
+
+    // checks the time stamps for both altitude and acceleration timestamps
+    if (currentTimestamp_ms <= lastTimestamp_ms)
+    {
+        return;
+    }
+    if(accel.x.timestamp_ms <= lastTimestamp_ms)
+    {
+        return;
+    }
+    
+    // Compute time step in seconds (dt).
+    const float dt = (static_cast<float>(currentTimestamp_ms - lastTimestamp_ms)) * MILLISECONDS_TO_SECONDS;
 
     // Subtract gravity from the measured acceleration on the identified vertical axis.
     inertialVerticalAcceleration = (rawAcl[verticalAxis] * static_cast<float>(verticalDirection)) - g;


### PR DESCRIPTION
… streamed at 50hz. If bad data is thrown out. Added a new way of predicting apogee using the simulation function.

## Description

### Summary of Changes
- added a new apogee prediction method and fixed the VVE account for duplicate time stamps

### Motivation
- fix the errors that are caused by altitude running at 50Hz

---

## Testing

Check all that apply:

- [x] I have added or modified tests to cover these changes.
- [ ] I have manually tested the changes on the target device(s) or environment(s).
- [ ] Existing tests were reviewed to ensure they still work as expected.
- [ ] If tests were not added or modified, explain why:
  > (Provide reasoning here)

---

## Building

- [ ] This change successfully builds in **at least one** of the following environments:
  - [x] Native repo
  - [ ] Target device(s) (e.g., MARTHA)
- [ ] If the build fails in any environment, explain why:
  > (Provide reasoning here)

---

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code where necessary for clarity.
- [x] I have made corresponding updates to documentation (if applicable).
