### PR TITLE
refactor: rename StateMachine to BasicStateMachine

### DIFF
--- a/include/simulation/Serial_Sim.h
+++ b/include/simulation/Serial_Sim.h
@@ -3,8 +3,8 @@
 
 #include "Adafruit_Sensor.h"
 #include "ArduinoHAL.h"
+#include "state_estimation/BasicStateMachine.h"
 #include "state_estimation/BurnoutStateMachine.h"
-#include "state_estimation/StateMachine.h"
 
 /**
  * @brief Serial-based sensor/flight simulation singleton for hardware-in-the-loop.

--- a/include/state_estimation/BasicStateMachine.h
+++ b/include/state_estimation/BasicStateMachine.h
@@ -1,5 +1,5 @@
-#ifndef FLIGHT_STATE_MACHINE_H
-#define FLIGHT_STATE_MACHINE_H
+#ifndef FLIGHT_BASIC_STATE_MACHINE_H
+#define FLIGHT_BASIC_STATE_MACHINE_H
 
 #include "data_handling/DataPoint.h"
 #include "data_handling/DataSaver.h"
@@ -15,8 +15,8 @@
  * @note When to use: standard flights where launch->coast->descent transitions
  *       are driven by detectors and logging is desired at each change.
  */
-class StateMachine : public BaseStateMachine {
-  public: 
+class BasicStateMachine : public BaseStateMachine {
+  public:
     /**
      * @brief Wire dependencies for the state machine.
      * @param dataSaver  Logger used to persist state changes.
@@ -26,8 +26,8 @@ class StateMachine : public BaseStateMachine {
      * @note When to use: build once during setup with already configured
      *       estimator/detector instances.
      */
-    StateMachine(IDataSaver* dataSaver, LaunchDetector* launchDetector, ApogeeDetector* apogeeDetector, 
-                 VerticalVelocityEstimator* verticalVelocityEstimator, FastLaunchDetector* fastLaunchDetector);
+    BasicStateMachine(IDataSaver* dataSaver, LaunchDetector* launchDetector, ApogeeDetector* apogeeDetector,
+                      VerticalVelocityEstimator* verticalVelocityEstimator, FastLaunchDetector* fastLaunchDetector);
 
     /**
      * @brief Process new sensor data and transition states if thresholds are met.

--- a/include/state_estimation/README.md
+++ b/include/state_estimation/README.md
@@ -10,6 +10,6 @@ Tools for detecting flight events, fusing sensors, and managing rocket flight-st
 - `GroundLevelEstimator.h`: Learns launch-site altitude pre-launch, then converts ASL to AGL after launch; use to normalize baro data.
 - `LaunchDetector.h`: Sliding-window accelerometer detector that marks liftoff when sustained acceleration exceeds a threshold; use to gate launch-critical events.
 - `StateEstimationTypes.h`: Shared data structures (e.g., `AccelerationTriplet`) passed among estimators and state machines.
-- `StateMachine.h`: Nominal flight state machine that advances through phases using launch/apogee detectors and logs transitions.
+- `BasicStateMachine.h`: Nominal flight state machine that advances through phases using launch/apogee detectors and logs transitions.
 - `States.h`: Enum of discrete flight states used across state machines they are all ordered from sequentially (earliest to latest) but not all states are used by all state machines but if STATE_A > STATE_B then STATE_A always occurs after STATE_B.
 - `VerticalVelocityEstimator.h`: 1D Kalman filter fusing accelerometer and barometer to estimate altitude, vertical velocity, and inertial acceleration; feed its outputs to detectors and state machines.

--- a/src/state_estimation/BasicStateMachine.cpp
+++ b/src/state_estimation/BasicStateMachine.cpp
@@ -1,15 +1,15 @@
 #include "ArduinoHAL.h"
 
 #include "data_handling/DataNames.h"
+#include "state_estimation/BasicStateMachine.h"
 #include "state_estimation/StateEstimationTypes.h"
-#include "state_estimation/StateMachine.h"
 
 
-StateMachine::StateMachine(IDataSaver* dataSaver,
-                           LaunchDetector* launchDetector,
-                           ApogeeDetector* apogeeDetector,
-                           VerticalVelocityEstimator* verticalVelocityEstimator,
-                           FastLaunchDetector* fastLaunchDetector)
+BasicStateMachine::BasicStateMachine(IDataSaver* dataSaver,
+                                     LaunchDetector* launchDetector,
+                                     ApogeeDetector* apogeeDetector,
+                                     VerticalVelocityEstimator* verticalVelocityEstimator,
+                                     FastLaunchDetector* fastLaunchDetector)
     : BaseStateMachine(STATE_ARMED),
       dataSaver_(dataSaver),
       launchDetector_(launchDetector),
@@ -19,7 +19,7 @@ StateMachine::StateMachine(IDataSaver* dataSaver,
 {
 }
 
-int StateMachine::update(const AccelerationTriplet& accel, const DataPoint& alt) {
+int BasicStateMachine::update(const AccelerationTriplet& accel, const DataPoint& alt) {
     // Update the state.
     switch (getFlightState()) {
         case STATE_ARMED:

--- a/test/test_basic_state_machine/main.cpp
+++ b/test/test_basic_state_machine/main.cpp
@@ -1,6 +1,6 @@
 #include "unity.h"
 #include "SimpleSimulation.h"   
-#include "state_estimation/StateMachine.h"
+#include "state_estimation/BasicStateMachine.h"
 #include "data_handling/DataPoint.h"
 #include "data_handling/DataSaverSPI.h"
 #include "DataSaver_mock.h"
@@ -33,7 +33,7 @@ void test_init(){
     ApogeeDetector ad;
     VerticalVelocityEstimator vve;
     FastLaunchDetector fld(30, 500);
-    StateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
+    BasicStateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
 
     TEST_ASSERT_EQUAL(STATE_ARMED, sm.getState());
 }
@@ -43,7 +43,7 @@ void test_launch(){
     ApogeeDetector ad;
     VerticalVelocityEstimator vve;
     FastLaunchDetector fld(30, 500);
-    StateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
+    BasicStateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
 
     // Start sim
     SimpleSimulator sim(10000, 70, 3000, 10);
@@ -77,7 +77,7 @@ void test_apogee_detection(){
     ApogeeDetector ad;
     VerticalVelocityEstimator vve;
     FastLaunchDetector fld(30, 500);
-    StateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
+    BasicStateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
 
     // Start sim
     SimpleSimulator sim(3000, 70, 2000, 5);
@@ -116,7 +116,7 @@ void test_apogee_detection_noise(){
     ApogeeDetector ad;
     VerticalVelocityEstimator vve;
     FastLaunchDetector fld(30, 500);
-    StateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
+    BasicStateMachine sm(dataSaverPtr, &lp, &ad, &vve, &fld);
 
     // Start sim
     SimpleSimulator sim(10000, 70, 3000, 10);
@@ -159,7 +159,7 @@ void test_fast_launch_with_revert(){
     flash = new Adafruit_SPIFlash();
     dss = new DataSaverSPI(100, flash);
 
-    StateMachine sm(dss, &lp, &ad, &vve, &fld);
+    BasicStateMachine sm(dss, &lp, &ad, &vve, &fld);
 
     //feed stateMachine one point of acceleration data to trigger fld
     DataPoint fldaclX(0, 100);
@@ -215,7 +215,7 @@ void test_fast_launch_with_confirm(){
     flash = new Adafruit_SPIFlash();
     dss = new DataSaverSPI(100, flash);
 
-    StateMachine sm(dss, &lp, &ad, &vve, &fld);
+    BasicStateMachine sm(dss, &lp, &ad, &vve, &fld);
 
     // Start sim
     SimpleSimulator sim(10000, 70, 3000, 10);

--- a/test/test_basic_state_machine/test_basic_state_machine_csv.cpp
+++ b/test/test_basic_state_machine/test_basic_state_machine_csv.cpp
@@ -5,7 +5,7 @@
 #include <cstdlib>
 #include <cmath>
 #include "unity.h"
-#include "state_estimation/StateMachine.h"
+#include "state_estimation/BasicStateMachine.h"
 #include "state_estimation/LaunchDetector.h"
 #include "state_estimation/ApogeeDetector.h"
 #include "state_estimation/VerticalVelocityEstimator.h"
@@ -14,7 +14,7 @@
 #include "../CSVMockData.h"
 
 /**
- * Test the StateMachine using real flight data from CSV.
+ * Test the BasicStateMachine using real flight data from CSV.
  * This test reads sensor data from a CSV file, feeds it into the state machine,
  * and logs the results including launch and apogee predictions.
  */
@@ -28,7 +28,7 @@ void test_state_machine_with_real_data(void) {
     VerticalVelocityEstimator vve;
     DataSaverMock dataSaver;
     FastLaunchDetector fld (30, 500);
-    StateMachine sm(&dataSaver, &lp, &ad, &vve, &fld);
+    BasicStateMachine sm(&dataSaver, &lp, &ad, &vve, &fld);
     
     // Create output CSV file for analysis
     std::ofstream outputFile("state_machine_results.csv");


### PR DESCRIPTION
## Summary

Closes #30. Mechanical rename of the existing nominal-flight `StateMachine` to `BasicStateMachine` so the upcoming `BurnoutAwareStateMachine` has clear naming contrast against `BaseStateMachine` / `BurnoutStateMachine` / `BasicStateMachine`.

## Changes

- `include/state_estimation/StateMachine.h` → `BasicStateMachine.h`. Header guard `FLIGHT_STATE_MACHINE_H` → `FLIGHT_BASIC_STATE_MACHINE_H`. Class `StateMachine` → `BasicStateMachine`.
- `src/state_estimation/StateMachine.cpp` → `BasicStateMachine.cpp`. Include retargeted. Constructor + `update()` definitions retargeted.
- `include/simulation/Serial_Sim.h` switched to the new include and re-sorted the two state-machine headers alphabetically.
- `include/state_estimation/README.md` entry updated.
- `test/test_state_machine/` → `test/test_basic_state_machine/` (PlatformIO native test runner picks tests up by directory name). CSV test file renamed in parallel. All six `StateMachine sm(...)` constructions and includes flipped to `BasicStateMachine`.

No behavior change.

## Verification

- `grep -rn '[^a-zA-Z_]StateMachine[^a-zA-Z_]'` (excluding `Base/Burnout/Basic*` prefixes) returns nothing across `.cpp/.h/.md`.
- `clang++ -std=c++11 -Iinclude -Ihal -Itest -c` compiles cleanly for `BasicStateMachine.cpp`, `BurnoutStateMachine.cpp`, and `BaseStateMachine.cpp`.

Closes #30